### PR TITLE
Changing maxSdk for legacy permissions to 32

### DIFF
--- a/Sensory/src/main/AndroidManifest.xml
+++ b/Sensory/src/main/AndroidManifest.xml
@@ -6,12 +6,12 @@
     />
   <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="29"
+        android:maxSdkVersion="32"
     />
   <uses-permission android:name="android.permission.FLASHLIGHT" />
   <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="29"
+        android:maxSdkVersion="32"
     />
   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
   <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />

--- a/Sensory/src/main/java/com/google/android/sensory/example/SensingApplication.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/example/SensingApplication.kt
@@ -59,16 +59,17 @@ class SensingApplication : Application(), DataCaptureConfig.Provider {
               }
           )
       )
+    SensingEngineProvider.init(sensingEngineConfiguration)
     /**
      * Local hapi fhir server was used to test the following. Add
      * [FhirEngineConfiguration.serverConfiguration] for your own fhir server.
      */
-    SensingEngineProvider.init(sensingEngineConfiguration)
     FhirEngineProvider.init(
       FhirEngineConfiguration(
         enableEncryptionIfSupported = true,
-        DatabaseErrorStrategy.RECREATE_AT_OPEN,
-        com.google.android.fhir.ServerConfiguration(properties.getProperty("FHIR_BASE_URL"))
+        databaseErrorStrategy = DatabaseErrorStrategy.RECREATE_AT_OPEN,
+        serverConfiguration =
+          com.google.android.fhir.ServerConfiguration(properties.getProperty("FHIR_BASE_URL"))
       )
     )
   }


### PR DESCRIPTION
Solves Issue #1 

Checked on Pixel 4 models
APIs: 29, 31, 32, 33, 34

API 30 still has some camera issue. Raised another issue [here](https://github.com/google-research/CVD-paper-mobile-camera-example/issues/3).