### PR TITLE
Allowing re-take of image / video for same participant

### DIFF
--- a/Sensory/src/main/java/com/google/android/sensory/sensing_sdk/capture/CaptureViewModel.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/sensing_sdk/capture/CaptureViewModel.kt
@@ -75,21 +75,24 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
     captureInfo: CaptureInfo,
     captureResultCollector: suspend ((Flow<SensorCaptureResult>) -> Unit)
   ) {
-    if (captureInfo.captureId != null) {
-      // delete everything in folder associated with this captureId to re-capture
-      val file =
-        File(
-          Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-          captureInfo.captureFolder
-        )
-      file.deleteRecursively()
-    } else {
-      captureInfo.apply { captureId = UUID.randomUUID().toString() }
+    viewModelScope.launch {
+      if (captureInfo.captureId != null) {
+        // delete everything in folder associated with this captureId to re-capture
+        val file =
+          File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            captureInfo.captureFolder
+          )
+        file.deleteRecursively()
+      } else {
+        captureInfo.apply { captureId = UUID.randomUUID().toString() }
+      }
     }
     this.captureInfo = captureInfo
     CoroutineScope(context = Dispatchers.IO).launch { captureResultCollector(captureResultFlow) }
   }
   fun processRecord(camera: Camera2InteropSensor) {
+
     if (this::recordingGate.isInitialized && recordingGate.isOpen) {
       recordingGate.completeAndClose()
       countDownTimer.cancel()
@@ -98,32 +101,32 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
       }
       return
     }
-    recordingGate = FlowGate.createClosed()
-    if (!isPhoneSafeToUse.value!!) {
-      isPhoneSafeToUse.postValue(false)
-    }
-    // Get stream of images while recording
-    val recordingImages = recordingGate.passThrough(camera.dataPublisher())
-
-    // Compatibility layer between camerax ImageProxy and camera2 Image
-    SharedImageProxy.asImagePublisher(recordingImages) // Write from stream to disk as JPEGs
-      .subscribe(
-        WriteJpegFutureSubscriber.builder()
-          .setFileSupplier { getCameraResourceFile() }
-          .setTotalFrames(Long.MAX_VALUE)
-          .build()
-      )
-    val captureResultStream = recordingGate.passThrough(camera.captureResultPublisher())
-    val cameraMetadataSaver =
-      StreamToTsvSubscriber.builder<CaptureResult>()
-        .setTsvWriter(TSV_WRITER)
-        .setSingleFile(getCameraMetadataFile())
-        .build()
-    captureResultStream.subscribe(cameraMetadataSaver)
-
-    // Open the recording stream
-    recordingGate.open()
     viewModelScope.launch {
+      recordingGate = FlowGate.createClosed()
+      if (!isPhoneSafeToUse.value!!) {
+        isPhoneSafeToUse.postValue(false)
+      }
+      // Get stream of images while recording
+      val recordingImages = recordingGate.passThrough(camera.dataPublisher())
+
+      // Compatibility layer between camerax ImageProxy and camera2 Image
+      SharedImageProxy.asImagePublisher(recordingImages) // Write from stream to disk as JPEGs
+        .subscribe(
+          WriteJpegFutureSubscriber.builder()
+            .setFileSupplier { getCameraResourceFile() }
+            .setTotalFrames(Long.MAX_VALUE)
+            .build()
+        )
+      val captureResultStream = recordingGate.passThrough(camera.captureResultPublisher())
+      val cameraMetadataSaver =
+        StreamToTsvSubscriber.builder<CaptureResult>()
+          .setTsvWriter(TSV_WRITER)
+          .setSingleFile(getCameraMetadataFile())
+          .build()
+      captureResultStream.subscribe(cameraMetadataSaver)
+
+      // Open the recording stream
+      recordingGate.open()
       _captureResultFlow.emit(SensorCaptureResult.Started(captureInfo.captureId!!))
       // timer in a different coroutine
       startTimer()

--- a/Sensory/src/main/java/com/google/android/sensory/sensing_sdk/db/impl/dao/ResourceInfoDao.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/sensing_sdk/db/impl/dao/ResourceInfoDao.kt
@@ -27,7 +27,7 @@ import com.google.android.sensory.sensing_sdk.model.ResourceInfo
 
 @Dao
 internal abstract class ResourceInfoDao {
-  @Insert(onConflict = OnConflictStrategy.ABORT)
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
   abstract suspend fun insertResourceInfoEntity(resourceInfoEntity: ResourceInfoEntity)
 
   @Transaction


### PR DESCRIPTION
Solves #15 

- Deleting older captured data in a separate coroutine

- TESTED: First time captured PPG images had timestamp 9:24am. Without submitting the questionnaire captured PPG again. The timestamp for captured PPG images was 9:25am.