### PR TITLE
Adding frameNumber in filepaths for easier processing in the backend

### DIFF
--- a/Sensory/src/main/java/com/google/android/sensory/fhir_data/PPGSensorCaptureViewHolderFactory.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/fhir_data/PPGSensorCaptureViewHolderFactory.kt
@@ -144,7 +144,7 @@ object PPGSensorCaptureViewHolderFactory :
                     CaptureSettings(
                       fileTypeMap = mapOf(SensorType.CAMERA to "jpeg"),
                       metaDataTypeMap = mapOf(SensorType.CAMERA to "tsv"),
-                      titleMap = mapOf(SensorType.CAMERA to SensingApplication.APP_VERSION),
+                      contextMap = mapOf(SensorType.CAMERA to SensingApplication.APP_VERSION),
                       captureTitle = QUESTION_TITLE,
                       ppgTimer = 30
                     ),

--- a/Sensory/src/main/java/com/google/android/sensory/fhir_data/PhotoCaptureViewHolderFactory.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/fhir_data/PhotoCaptureViewHolderFactory.kt
@@ -147,7 +147,7 @@ object PhotoCaptureViewHolderFactory :
                     CaptureSettings(
                       fileTypeMap = mapOf(SensorType.CAMERA to "jpeg"),
                       metaDataTypeMap = mapOf(SensorType.CAMERA to "tsv"),
-                      titleMap = mapOf(SensorType.CAMERA to SensingApplication.APP_VERSION),
+                      contextMap = mapOf(SensorType.CAMERA to SensingApplication.APP_VERSION),
                       captureTitle = QUESTION_TITLE
                     ),
                   captureId = captureId,

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureSettings.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureSettings.kt
@@ -26,9 +26,9 @@ data class CaptureSettings(
   val fileTypeMap: Map<SensorType, String>,
   /** The mimetype map for metadata files captured via a sensor. */
   val metaDataTypeMap: Map<SensorType, String>,
-  /** The title map for naming conventions of files captured via a sensor. */
-  val titleMap: Map<SensorType, String>,
-  /** The capture title used for naming folder that stores all sensors' captured data. */
+  /** The context is appended at the end of a filename being produced while capturing. */
+  val contextMap: Map<SensorType, String>,
+  /** The capture title is appended next to ParticipantID in a filename being produced while capturing. */
   val captureTitle: String,
   /** Seconds one wants to record PPG video. */
   val ppgTimer: Int = 0

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureSettings.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureSettings.kt
@@ -28,7 +28,10 @@ data class CaptureSettings(
   val metaDataTypeMap: Map<SensorType, String>,
   /** The context is appended at the end of a filename being produced while capturing. */
   val contextMap: Map<SensorType, String>,
-  /** The capture title is appended next to ParticipantID in a filename being produced while capturing. */
+  /**
+   * The capture title is appended next to ParticipantID in a filename being produced while
+   * capturing.
+   */
   val captureTitle: String,
   /** Seconds one wants to record PPG video. */
   val ppgTimer: Int = 0

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
@@ -69,7 +69,7 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   val isPhoneSafeToUse = MutableLiveData<Boolean>(false)
   private lateinit var countDownTimer: CountDownTimer
   val timerLiveData = MutableLiveData<Long?>(null)
-  private var frameCount = 0
+  private var frameNumber = 0
   val captured = MutableLiveData<Boolean?>(null)
 
   fun setupCaptureResultFlow(
@@ -155,14 +155,17 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
     )
   }
 
-  /** Storage folder is fetched from [captureInfo]. This is supposed to contain sub-folders for different [SensorType]s used in a [CaptureType]. Here it's only [SensorType.CAMERA].
-   *  Format of filename is Participant<PatientID>_<captureTitle>_<frameCount>_<timestamp>_<context>.<jpeg/tsv>
-   * */
+  /**
+   * Storage folder is fetched from [captureInfo]. This is supposed to contain sub-folders for
+   * different [SensorType]s used in a [CaptureType]. Here it's only [SensorType.CAMERA]. Format of
+   * filename is
+   * Participant<PatientID>_<captureTitle>_<frameNumber>_<timestamp>_<context>.<jpeg/tsv>
+   */
   private fun getCameraResourceFile(): File {
     val folder = "${captureInfo.captureFolder}/${SensorType.CAMERA}"
     val filename =
-      "Participant${captureInfo.participantId}_${captureInfo.captureSettings.captureTitle}_${frameCount}_${System.currentTimeMillis()}_${captureInfo.captureSettings.contextMap[SensorType.CAMERA]}.${captureInfo.captureSettings.fileTypeMap[SensorType.CAMERA]}"
-    frameCount++;
+      "Participant${captureInfo.participantId}_${captureInfo.captureSettings.captureTitle}_${frameNumber}_${System.currentTimeMillis()}_${captureInfo.captureSettings.contextMap[SensorType.CAMERA]}.${captureInfo.captureSettings.fileTypeMap[SensorType.CAMERA]}"
+    frameNumber++
     val filePath = "$folder/$filename"
     val fileFolder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
     return File(fileFolder, filePath)
@@ -180,20 +183,20 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   private suspend fun startTimer() {
     countDownTimer =
       object : CountDownTimer(1000L * captureInfo.captureSettings.ppgTimer, 1000) {
-        override fun onTick(millisUntilFinished: Long) {
-          timerLiveData.postValue(millisUntilFinished)
-        }
+          override fun onTick(millisUntilFinished: Long) {
+            timerLiveData.postValue(millisUntilFinished)
+          }
 
-        override fun onFinish() {
-          if (recordingGate.isOpen) {
-            viewModelScope.launch {
-              _captureResultFlow.emit(
-                SensorCaptureResult.CaptureComplete(captureInfo.captureId!!)
-              )
+          override fun onFinish() {
+            if (recordingGate.isOpen) {
+              viewModelScope.launch {
+                _captureResultFlow.emit(
+                  SensorCaptureResult.CaptureComplete(captureInfo.captureId!!)
+                )
+              }
             }
           }
         }
-      }
         .start()
   }
 

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
@@ -69,6 +69,7 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   val isPhoneSafeToUse = MutableLiveData<Boolean>(false)
   private lateinit var countDownTimer: CountDownTimer
   val timerLiveData = MutableLiveData<Long?>(null)
+  private var frameCount = 0
   val captured = MutableLiveData<Boolean?>(null)
 
   fun setupCaptureResultFlow(
@@ -154,10 +155,14 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
     )
   }
 
+  /** Storage folder is fetched from [captureInfo]. This is supposed to contain sub-folders for different [SensorType]s used in a [CaptureType]. Here it's only [SensorType.CAMERA].
+   *  Format of filename is Participant<PatientID>_<captureTitle>_<frameCount>_<timestamp>_<context>.<jpeg/tsv>
+   * */
   private fun getCameraResourceFile(): File {
     val folder = "${captureInfo.captureFolder}/${SensorType.CAMERA}"
     val filename =
-      "Participant${captureInfo.participantId}_${captureInfo.captureSettings.captureTitle}_data_${System.currentTimeMillis()}_${captureInfo.captureSettings.titleMap[SensorType.CAMERA]}.${captureInfo.captureSettings.fileTypeMap[SensorType.CAMERA]}"
+      "Participant${captureInfo.participantId}_${captureInfo.captureSettings.captureTitle}_${frameCount}_${System.currentTimeMillis()}_${captureInfo.captureSettings.contextMap[SensorType.CAMERA]}.${captureInfo.captureSettings.fileTypeMap[SensorType.CAMERA]}"
+    frameCount++;
     val filePath = "$folder/$filename"
     val fileFolder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
     return File(fileFolder, filePath)
@@ -166,7 +171,7 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   private fun getCameraMetadataFile(): File {
     val folder = "${captureInfo.captureFolder}/${SensorType.CAMERA}"
     val filename =
-      "Participant_${captureInfo.participantId}_${captureInfo.captureSettings.captureTitle}_metadata_${System.currentTimeMillis()}_${captureInfo.captureSettings.titleMap[SensorType.CAMERA]}.${captureInfo.captureSettings.metaDataTypeMap[SensorType.CAMERA]}"
+      "Participant_${captureInfo.participantId}_${captureInfo.captureSettings.captureTitle}_${System.currentTimeMillis()}_${captureInfo.captureSettings.contextMap[SensorType.CAMERA]}.${captureInfo.captureSettings.metaDataTypeMap[SensorType.CAMERA]}"
     val filePath = "$folder/$filename"
     val fileFolder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
     return File(fileFolder, filePath)
@@ -175,20 +180,20 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   private suspend fun startTimer() {
     countDownTimer =
       object : CountDownTimer(1000L * captureInfo.captureSettings.ppgTimer, 1000) {
-          override fun onTick(millisUntilFinished: Long) {
-            timerLiveData.postValue(millisUntilFinished)
-          }
+        override fun onTick(millisUntilFinished: Long) {
+          timerLiveData.postValue(millisUntilFinished)
+        }
 
-          override fun onFinish() {
-            if (recordingGate.isOpen) {
-              viewModelScope.launch {
-                _captureResultFlow.emit(
-                  SensorCaptureResult.CaptureComplete(captureInfo.captureId!!)
-                )
-              }
+        override fun onFinish() {
+          if (recordingGate.isOpen) {
+            viewModelScope.launch {
+              _captureResultFlow.emit(
+                SensorCaptureResult.CaptureComplete(captureInfo.captureId!!)
+              )
             }
           }
         }
+      }
         .start()
   }
 


### PR DESCRIPTION
Fixes #27 

1. Removing keywords data / metadata in filepaths as it can be inferred from the file extension
2. Maintaining a frameNumber in CaptureViewModel. This is appended to the filepath for easier processing in the backend