### PR TITLE
Recapture feature implementation

### DIFF
--- a/Sensory/src/main/java/com/google/android/sensory/ScreenerFragment.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/ScreenerFragment.kt
@@ -44,7 +44,7 @@ class ScreenerFragment : Fragment(R.layout.fragment_screening) {
     setUpActionBar()
     setHasOptionsMenu(true)
     updateArguments()
-    onBackPressed()
+    registerBackPressCallback()
     observeResourcesSaveAction()
     if (savedInstanceState == null) {
       addQuestionnaireFragment()
@@ -63,7 +63,7 @@ class ScreenerFragment : Fragment(R.layout.fragment_screening) {
         true
       }
       android.R.id.home -> {
-        showCancelScreenerQuestionnaireAlertDialog()
+        onBackPressed()
         true
       }
       else -> true
@@ -87,7 +87,7 @@ class ScreenerFragment : Fragment(R.layout.fragment_screening) {
     val questionnaireFragment =
       childFragmentManager.findFragmentByTag(QUESTIONNAIRE_FRAGMENT_TAG) as QuestionnaireFragment?
     childFragmentManager.commit {
-      replace(
+      add(
         R.id.screener_container,
         questionnaireFragment
           ?: QuestionnaireFragment.builder()
@@ -127,10 +127,16 @@ class ScreenerFragment : Fragment(R.layout.fragment_screening) {
     alertDialog?.show()
   }
 
+  private fun registerBackPressCallback() {
+    activity?.onBackPressedDispatcher?.addCallback(viewLifecycleOwner) { onBackPressed() }
+  }
+
   private fun onBackPressed() {
-    activity?.onBackPressedDispatcher?.addCallback(viewLifecycleOwner) {
-      showCancelScreenerQuestionnaireAlertDialog()
+    if (childFragmentManager.backStackEntryCount >= 1) {
+      childFragmentManager.popBackStack()
+      return
     }
+    showCancelScreenerQuestionnaireAlertDialog()
   }
 
   private fun observeResourcesSaveAction() {

--- a/Sensory/src/main/res/layout/fragment_conjunctiva_instructions.xml
+++ b/Sensory/src/main/res/layout/fragment_conjunctiva_instructions.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:ignore="contentDescription"
+    android:background="@android:color/white"
 >
 
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/Sensory/src/main/res/layout/fragment_fingernails_closed_instructions.xml
+++ b/Sensory/src/main/res/layout/fragment_fingernails_closed_instructions.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:ignore="contentDescription"
+    android:background="@android:color/white"
 >
 
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/Sensory/src/main/res/layout/fragment_fingernails_open_instructions.xml
+++ b/Sensory/src/main/res/layout/fragment_fingernails_open_instructions.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:ignore="contentDescription"
+    android:background="@android:color/white"
 >
 
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/Sensory/src/main/res/layout/fragment_ppg_instructions.xml
+++ b/Sensory/src/main/res/layout/fragment_ppg_instructions.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:ignore="contentDescription"
+    android:background="@android:color/white"
 >
 
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/Sensory/src/main/res/layout/fragment_screening.xml
+++ b/Sensory/src/main/res/layout/fragment_screening.xml
@@ -9,6 +9,7 @@
         android:id="@+id/screener_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@android:color/white"
     />
 
 </FrameLayout>

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureFragment.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureFragment.kt
@@ -316,7 +316,7 @@ class CaptureFragment : Fragment() {
 
   override fun onPause() {
     super.onPause()
-    captureViewModel.completePpgCapture()
+    captureViewModel.endPPGCapture()
     (requireActivity() as AppCompatActivity).supportActionBar?.show()
   }
 

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureFragment.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureFragment.kt
@@ -38,7 +38,6 @@ import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.lifecycleScope
 import com.google.android.fitbit.research.sensing.common.libraries.camera.Camera2InteropSensor
 import com.google.android.fitbit.research.sensing.common.libraries.camera.CameraXSensorV2
@@ -50,9 +49,9 @@ import com.google.android.sensing.model.CaptureType
 import java.util.Locale
 import java.util.Timer
 import java.util.TimerTask
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
 
 /**
  * Fragment that deals with all sensors: For now only camera with capture types being
@@ -101,8 +100,13 @@ class CaptureFragment : Fragment() {
   /**
    * A setter function: All details about the capture. Not passing via arguments as it requires API
    * >= 33.
+   *
+   * If [captureInfo.recapture] is true then [captureInfo.captureId] must not be null
    */
   fun setCaptureInfo(captureInfo: CaptureInfo) {
+    if (captureInfo.captureId == null) {
+      captureInfo.captureId = UUID.randomUUID().toString()
+    }
     this.captureInfo = captureInfo
   }
 
@@ -232,8 +236,7 @@ class CaptureFragment : Fragment() {
             )
           }
         }
-        captureViewModel.timerLiveData.distinctUntilChanged().observe(viewLifecycleOwner) {
-          if (it == null) return@observe
+        captureViewModel.timerLiveData.observe(viewLifecycleOwner) {
           val strDuration =
             String.format(
               Locale.ENGLISH,
@@ -243,40 +246,45 @@ class CaptureFragment : Fragment() {
             )
           recordTimer.text = strDuration
           ppgProgress.progress =
-            captureViewModel.captureInfo.captureSettings.ppgTimer -
+            captureViewModel.captureInfo.captureSettings!!.ppgTimer -
               TimeUnit.MILLISECONDS.toSeconds(it).toInt()
         }
       }
-      captureViewModel.captured.observe(viewLifecycleOwner) {
-        if (it == null) return@observe
-        if (!it) {
-          val toastText =
+      captureViewModel.captureResultLiveData.observe(viewLifecycleOwner) {
+        when (it) {
+          is SensorCaptureResult.Started -> {
             when (captureViewModel.captureInfo.captureType) {
-              CaptureType.VIDEO_PPG -> "Failed to save Video"
-              CaptureType.IMAGE -> "Failed to save Image"
+              CaptureType.VIDEO_PPG -> {
+                ppgInstruction.text = resources.getString(R.string.ppg_instruction_recording)
+                recordFab.setImageResource(R.drawable.videocam_off)
+                recordFab.imageTintList =
+                  ColorStateList.valueOf(
+                    ContextCompat.getColor(requireContext(), R.color.colorPrimary)
+                  )
+              }
+              CaptureType.IMAGE -> {
+                // No need to do anything here as Image capturing will end in a moment
+              }
             }
-          Toast.makeText(requireContext(), toastText, Toast.LENGTH_SHORT).show()
-          return@observe
-        }
-        val toastText =
-          when (captureViewModel.captureInfo.captureType) {
-            CaptureType.VIDEO_PPG -> "Video Saved"
-            CaptureType.IMAGE -> "Image Saved"
           }
-        Toast.makeText(requireContext(), toastText, Toast.LENGTH_SHORT).show()
-        finishCapturing()
-      }
-      lifecycleScope.launch {
-        captureViewModel.captureResultFlow.collect {
-          if (it is SensorCaptureResult.Started) {
-            ppgInstruction.text = resources.getString(R.string.ppg_instruction_recording)
-            recordFab.setImageResource(R.drawable.videocam_off)
-            recordFab.imageTintList =
-              ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.colorPrimary))
-          }
-          if (it is SensorCaptureResult.CaptureComplete) {
+          is SensorCaptureResult.CaptureComplete -> {
+            val toastText =
+              when (captureViewModel.captureInfo.captureType) {
+                CaptureType.VIDEO_PPG -> "Video Saved"
+                CaptureType.IMAGE -> "Image Saved"
+              }
+            Toast.makeText(requireContext(), toastText, Toast.LENGTH_SHORT).show()
             finishCapturing()
           }
+          is SensorCaptureResult.Failed -> {
+            val toastText =
+              when (captureViewModel.captureInfo.captureType) {
+                CaptureType.VIDEO_PPG -> "Failed to save Video"
+                CaptureType.IMAGE -> "Failed to save Image"
+              }
+            Toast.makeText(requireContext(), toastText, Toast.LENGTH_SHORT).show()
+          }
+          else -> {}
         }
       }
     }
@@ -302,9 +310,14 @@ class CaptureFragment : Fragment() {
   }
 
   private fun finishCapturing() {
-    captureViewModel.captureComplete()
-    setFragmentResult(CAPTURE_FRAGMENT_TAG, bundleOf(CAPTURED to true))
-    requireActivity().supportFragmentManager.popBackStack()
+    captureViewModel.invokeCaptureCompleteCallback()
+    setFragmentResult(TAG, bundleOf(CAPTURED to true))
+  }
+
+  override fun onPause() {
+    super.onPause()
+    captureViewModel.completeCapture()
+    (requireActivity() as AppCompatActivity).supportActionBar?.show()
   }
 
   companion object {

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureFragment.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureFragment.kt
@@ -316,7 +316,7 @@ class CaptureFragment : Fragment() {
 
   override fun onPause() {
     super.onPause()
-    captureViewModel.completeCapture()
+    captureViewModel.completePpgCapture()
     (requireActivity() as AppCompatActivity).supportActionBar?.show()
   }
 

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
@@ -28,6 +28,7 @@ import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
 import com.google.android.fitbit.research.sensing.common.libraries.camera.Camera2InteropActions
 import com.google.android.fitbit.research.sensing.common.libraries.camera.Camera2InteropSensor
@@ -42,12 +43,11 @@ import com.google.android.sensing.model.SensorType
 import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
 import java.io.File
-import java.util.UUID
+import java.util.Date
 import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -60,43 +60,31 @@ import kotlinx.coroutines.launch
 class CaptureViewModel(application: Application) : AndroidViewModel(application) {
   lateinit var captureInfo: CaptureInfo
 
-  private val _captureResultFlow = MutableSharedFlow<SensorCaptureResult>()
-  val captureResultFlow: Flow<SensorCaptureResult>
-    get() = _captureResultFlow
+  val captureResultLiveData = MutableLiveData<SensorCaptureResult>()
 
   lateinit var recordingGate: FlowGate
   val isPhoneSafeToUse = MutableLiveData<Boolean>(false)
   private lateinit var countDownTimer: CountDownTimer
-  val timerLiveData = MutableLiveData<Long?>(null)
+  val timerLiveData = MutableLiveData<Long>()
   private var frameNumber = 0
-  val captured = MutableLiveData<Boolean?>(null)
 
   private val internalStorageFolder: File
-    get() = getApplication<Application>().filesDir
+    get() =
+      if (captureInfo.recapture == true) getApplication<Application>().cacheDir
+      else getApplication<Application>().filesDir
 
   fun setupCaptureResultFlow(
     captureInfo: CaptureInfo,
     captureResultCollector: suspend ((Flow<SensorCaptureResult>) -> Unit)
   ) {
-    viewModelScope.launch {
-      if (captureInfo.captureId != null) {
-        // delete everything in folder associated with this captureId to re-capture
-        val file = File(internalStorageFolder, captureInfo.captureFolder)
-        file.deleteRecursively()
-      } else {
-        captureInfo.apply { captureId = UUID.randomUUID().toString() }
-      }
-    }
     this.captureInfo = captureInfo
-    CoroutineScope(context = Dispatchers.IO).launch { captureResultCollector(captureResultFlow) }
+    CoroutineScope(context = Dispatchers.IO).launch {
+      captureResultCollector(captureResultLiveData.asFlow())
+    }
   }
   fun processRecord(camera: Camera2InteropSensor) {
     if (this::recordingGate.isInitialized && recordingGate.isOpen) {
-      recordingGate.completeAndClose()
-      countDownTimer.cancel()
-      viewModelScope.launch {
-        _captureResultFlow.emit(SensorCaptureResult.CaptureComplete(captureInfo.captureId!!))
-      }
+      completeCapture()
       return
     }
     recordingGate = FlowGate.createClosed()
@@ -124,15 +112,14 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
 
     // Open the recording stream
     recordingGate.open()
-    viewModelScope.launch {
-      _captureResultFlow.emit(SensorCaptureResult.Started(captureInfo.captureId!!))
-      // timer in a different coroutine
-      startTimer()
-    }
+    captureResultLiveData.postValue(SensorCaptureResult.Started(captureInfo.captureId!!))
+    captureInfo.captureTime = Date()
+    startTimer()
   }
 
   // Safe to ignore CameraControl futures
   fun capturePhoto(camera: Camera2InteropSensor, context: Context) {
+    captureResultLiveData.postValue(SensorCaptureResult.Started(captureInfo.captureId!!))
     Futures.addCallback(
       Camera2InteropActions.captureSingleJpegWithMetadata(
         camera,
@@ -142,11 +129,13 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
       ),
       object : FutureCallback<Boolean?> {
         override fun onSuccess(success: Boolean?) {
-          captured.postValue(true)
+          captureResultLiveData.postValue(
+            SensorCaptureResult.CaptureComplete(captureInfo.captureId!!)
+          )
         }
 
         override fun onFailure(t: Throwable) {
-          captured.postValue(false)
+          captureResultLiveData.postValue(SensorCaptureResult.Failed(captureInfo.captureId!!, t))
         }
       },
       ContextCompat.getMainExecutor(context)
@@ -176,24 +165,29 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
     return File(internalStorageFolder, filePath)
   }
 
-  private suspend fun startTimer() {
-    countDownTimer =
-      object : CountDownTimer(1000L * captureInfo.captureSettings.ppgTimer, 1000) {
-          override fun onTick(millisUntilFinished: Long) {
-            timerLiveData.postValue(millisUntilFinished)
-          }
+  private fun startTimer() {
+    // timer in a different coroutine
+    viewModelScope.launch {
+      countDownTimer =
+        object : CountDownTimer(1000L * captureInfo.captureSettings.ppgTimer, 1000) {
+            override fun onTick(millisUntilFinished: Long) {
+              timerLiveData.postValue(millisUntilFinished)
+            }
 
-          override fun onFinish() {
-            if (recordingGate.isOpen) {
-              viewModelScope.launch {
-                _captureResultFlow.emit(
-                  SensorCaptureResult.CaptureComplete(captureInfo.captureId!!)
-                )
+            override fun onFinish() {
+              if (recordingGate.isOpen) {
+                viewModelScope.launch {
+                  if (recordingGate.isOpen) {
+                    captureResultLiveData.postValue(
+                      SensorCaptureResult.CaptureComplete(captureInfo.captureId!!)
+                    )
+                  }
+                }
               }
             }
           }
-        }
-        .start()
+          .start()
+    }
   }
 
   fun getCaptureRequestOptions(lockExposure: Boolean): CaptureRequestOptions {
@@ -235,17 +229,27 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   }
 
   /**
-   * This invokes [SensingEngine.onCaptureCompleteCallback] which emits [SensorCaptureResult] upon
-   * saving resources to database. Happens in [CoroutineScope] and not [viewModelScope] because the
-   * fragment and its viewModel can get destroyed before resources are saved into the database.
-   * Emitted [SensorCaptureResult] are collected here arnd re-emitted to the [_captureResultFlow]
-   * which in turn is collected by the application developers via [captureResultCollector]
+   * This invokes [SensingEngine.onCaptureComplete] which emits [SensorCaptureResult]. Invocation
+   * scope is a new [CoroutineScope] and not [viewModelScope] because [viewModelScope] will be
+   * cancelled when ViewModel will be cleared. And hence it will also cancel further emit of
+   * [SensorCaptureResult].
+   *
+   * Emitted [SensorCaptureResult] are collected here and posted to [captureResultLiveData] which in
+   * turn is collected by the application callback.
    */
-  fun captureComplete() {
+  fun invokeCaptureCompleteCallback() {
     CoroutineScope(context = Dispatchers.IO).launch {
       SensingEngineProvider.getOrCreateSensingEngine(getApplication())
         .onCaptureCompleteCallback(captureInfo)
-        .collect { _captureResultFlow.emit(it) }
+        .collect { captureResultLiveData.postValue(it) }
+    }
+  }
+
+  fun completeCapture() {
+    if (this::recordingGate.isInitialized && recordingGate.isOpen) {
+      recordingGate.completeAndClose()
+      countDownTimer.cancel()
+      captureResultLiveData.postValue(SensorCaptureResult.CaptureComplete(captureInfo.captureId!!))
     }
   }
 

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
@@ -84,7 +84,7 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   }
   fun processRecord(camera: Camera2InteropSensor) {
     if (this::recordingGate.isInitialized && recordingGate.isOpen) {
-      completePpgCapture()
+      endPPGCapture()
       return
     }
     recordingGate = FlowGate.createClosed()
@@ -245,7 +245,7 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
     }
   }
 
-  fun completePpgCapture() {
+  fun endPPGCapture() {
     if (this::recordingGate.isInitialized && recordingGate.isOpen) {
       recordingGate.completeAndClose()
       countDownTimer.cancel()

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
@@ -84,7 +84,7 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
   }
   fun processRecord(camera: Camera2InteropSensor) {
     if (this::recordingGate.isInitialized && recordingGate.isOpen) {
-      completeCapture()
+      completePpgCapture()
       return
     }
     recordingGate = FlowGate.createClosed()
@@ -245,7 +245,7 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
     }
   }
 
-  fun completeCapture() {
+  fun completePpgCapture() {
     if (this::recordingGate.isInitialized && recordingGate.isOpen) {
       recordingGate.completeAndClose()
       countDownTimer.cancel()

--- a/sensing/src/main/java/com/google/android/sensing/capture/SensorCaptureResult.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/SensorCaptureResult.kt
@@ -20,9 +20,15 @@ sealed class SensorCaptureResult {
 
   data class Started(val captureId: String) : SensorCaptureResult()
 
-  data class StateChange(val resourceInfoId: String) : SensorCaptureResult()
-
   data class CaptureComplete(val captureId: String) : SensorCaptureResult()
 
+  data class CaptureInfoCreated(val captureId: String) : SensorCaptureResult()
+
+  data class ResourceMetaInfoCreated(val resourceMetaInfoId: String) : SensorCaptureResult()
+
+  data class UploadRequestCreated(val uploadRequestId: String) : SensorCaptureResult()
+
   data class ResourcesStored(val captureId: String) : SensorCaptureResult()
+
+  data class Failed(val captureId: String, val t: Throwable) : SensorCaptureResult()
 }

--- a/sensing/src/main/java/com/google/android/sensing/model/CaptureInfo.kt
+++ b/sensing/src/main/java/com/google/android/sensing/model/CaptureInfo.kt
@@ -28,4 +28,5 @@ data class CaptureInfo(
   var captureId: String? = null,
   /** This is not persisted in database for now */
   val captureSettings: CaptureSettings,
+  val recapture: Boolean? = false,
 )

--- a/sensing/src/main/res/layout/fragment_image.xml
+++ b/sensing/src/main/res/layout/fragment_image.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@android:color/white"
 >
 
   <androidx.camera.view.PreviewView

--- a/sensing/src/main/res/layout/fragment_video_ppg.xml
+++ b/sensing/src/main/res/layout/fragment_video_ppg.xml
@@ -7,6 +7,7 @@
     android:layout_height="match_parent"
     android:keepScreenOn="true"
     tools:ignore="contentDescription"
+    android:background="@android:color/white"
 >
 
   <include


### PR DESCRIPTION
Fixes primarily https://github.com/google-research/CVD-paper-mobile-camera-example/issues/28 https://github.com/google-research/CVD-paper-mobile-camera-example/issues/15

Designing re-capturing of data
   a. if recapture == true, data is stored in internal cacheDir else filesDir
   b. On successful capture, we delete all previous data using the API deleteDataInCapture, move data from cacheDir to filesDir, and finally create db records.
   c. Need of this mechanism to prevent data loss stemming from this https://github.com/google-research/CVD-paper-mobile-camera-example/issues/28

TESTED following:-

New data is stored first in cacheDir and later moved to 'filesDir
Correct db records are seen
All back buttons and possible user flows have been tested in the Sensor app.
Successful upload tested

https://github.com/google-research/CVD-paper-mobile-camera-example/assets/22965002/e93894a6-2317-40d1-a946-6587607608eb


As a consequence of checking that all back flows are efficiently working we make few changes :-
1. fragments are placed in the view by doing `add` to backstack instead of replace
2. `parentFragmentsChildFragmentManager` is used in the QuestionnaireViewHolderFactories to handle fragment placing 
3.  register BackPressCallback in the ScreenerFragment
4. Add white background to avoid adding transparent backgrounds.
5. To handle backpress while recording we invoke the internal `endPPGCapture". 
6. _captureResultFlow is replaced by captureResultLiveData to simplify the above flows

Alternatively, we could have let application layer handle replacing of the obsolete data by making each capture invocation unique and hence unique captureId for each. In this case the application layer would need to cache the last data (in case recapture was attempted but not done), trigger the new `deleteDataInCapture` API (after successful capture) with the last captureId, and then finally delete the cached data because it would be no longer needed. This would just be a hustle for application developer hence we introduced the new recapture design with the `recapture` flag.