### PR TITLE
Batch Uploads: Streamline uploading

### DIFF
--- a/Sensory/src/main/java/com/google/android/sensory/HomeFragment.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/HomeFragment.kt
@@ -107,9 +107,9 @@ class HomeFragment : Fragment() {
       if (linearLayoutUploadStatus.visibility != View.VISIBLE) {
         // may add fade in animation here later
         linearLayoutUploadStatus.visibility = View.VISIBLE
-        updateUploadPercent(0, (syncUploadState as SyncUploadState.Started).totalRequests)
+        updateUploadPercent(0, (syncUploadState as SyncUploadState.Started).initialTotalRequests)
       } else if (syncUploadState is SyncUploadState.InProgress) {
-        updateUploadPercent(syncUploadState.completedRequests, syncUploadState.totalRequests)
+        updateUploadPercent(syncUploadState.completedRequests, syncUploadState.currentTotalRequests)
       }
     }
   }

--- a/sensing/src/main/java/com/google/android/sensing/upload/DefaultUploadRequestFetcher.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/DefaultUploadRequestFetcher.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.sensing.upload
+
+import com.google.android.sensing.SensingEngine
+import com.google.android.sensing.model.RequestStatus
+import com.google.android.sensing.model.UploadRequest
+
+/** Responsible for fetching [UploadRequest] that are pending to be uploaded. */
+interface UploadRequestFetcher {
+  suspend fun fetchForUpload(): List<UploadRequest>
+}
+
+class DefaultUploadRequestFetcher(private val sensingEngine: SensingEngine) : UploadRequestFetcher {
+  override suspend fun fetchForUpload(): List<UploadRequest> {
+    return (sensingEngine.listUploadRequest(status = RequestStatus.UPLOADING) +
+      sensingEngine.listUploadRequest(status = RequestStatus.PENDING))
+  }
+}

--- a/sensing/src/main/java/com/google/android/sensing/upload/SensingSynchronizer.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/SensingSynchronizer.kt
@@ -48,6 +48,7 @@ class SensingSynchronizer(
         .upload(uploadRequestList)
         .onEach { uploadResultProcessor.process(it) }
         .runningFold(initialSyncUploadState, ::calculateSyncUploadState)
+        // initialSyncUploadState is dropped
         .drop(1)
         .collect { emit(it) }
       totalRequests += uploadRequestList.size

--- a/sensing/src/main/java/com/google/android/sensing/upload/SensingSynchronizer.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/SensingSynchronizer.kt
@@ -30,12 +30,9 @@ class SensingSynchronizer(
 ) {
 
   /**
-   * Sync Upload API. It fetches [UploadRequest]s, invokes [uploader], collects [UploadResult]s
-   * processes them using [UploadResult]s by [uploadResultProcessor]. At each stage it emits
-   * [SyncUploadState]s.
-   *
-   * TODO Persist the terminal SyncUploadState due to this
-   * [issue](https://github.com/google/android-fhir/issues/2119).
+   * Sync Upload API. It fetches [UploadRequest]s using [uploadRequestFetcher], invokes [uploader],
+   * collects [UploadResult]s and processes them using [uploadResultProcessor]. At each stage it
+   * emits [SyncUploadState]s.
    */
   suspend fun synchronize(): Flow<SyncUploadState> = flow {
     var uploadRequestList = uploadRequestFetcher.fetchForUpload()

--- a/sensing/src/main/java/com/google/android/sensing/upload/SensingSynchronizer.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/SensingSynchronizer.kt
@@ -16,15 +16,15 @@
 
 package com.google.android.sensing.upload
 
-import com.google.android.sensing.SensingEngine
-import com.google.android.sensing.model.RequestStatus
 import com.google.android.sensing.model.UploadResult
-import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.scan
 
 class SensingSynchronizer(
-  private val sensingEngine: SensingEngine,
+  private val uploadRequestFetcher: UploadRequestFetcher,
   private val uploader: Uploader,
   private val uploadResultProcessor: UploadResultProcessor
 ) {
@@ -34,83 +34,68 @@ class SensingSynchronizer(
    * processes them using [UploadResult]s by [uploadResultProcessor]. At each stage it emits
    * [SyncUploadState]s.
    *
-   * TODO Upload until there is no upload requests in the database. Use UploadRequestPublisher
-   *
    * TODO Persist the terminal SyncUploadState due to this
    * [issue](https://github.com/google/android-fhir/issues/2119).
    */
   suspend fun synchronize(): Flow<SyncUploadState> = flow {
-    val uploadRequestList =
-      (sensingEngine.listUploadRequest(status = RequestStatus.UPLOADING) +
-        sensingEngine.listUploadRequest(status = RequestStatus.PENDING))
+    var uploadRequestList = uploadRequestFetcher.fetchForUpload()
+    emit(SyncUploadState.Started(initialTotalRequests = uploadRequestList.size))
+    var totalRequests = 0
+    // Following is to bootstrap new state calculation based on previous "InProgress" states
+    val initialSyncUploadState =
+      SyncUploadState.InProgress(currentTotalRequests = uploadRequestList.size)
 
-    var syncUploadState = SyncUploadState.Started(uploadRequestList.size) as SyncUploadState
-    emit(syncUploadState)
-    if (uploadRequestList.isNotEmpty()) {
-      // Following line is a workaround to calculate new states based on previous "InProgress"
-      // states.
-      syncUploadState =
-        SyncUploadState.InProgress(
-          totalRequests = uploadRequestList.size,
-          completedRequests = 0,
-          currentTotalBytes = 0,
-          currentCompletedBytes = 0
-        )
-      // https://stackoverflow.com/questions/60761812/unable-to-execute-code-after-kotlin-flow-collect
-      uploader.upload(uploadRequestList).collect {
-        uploadResultProcessor.process(it)
-        syncUploadState =
-          calculateSyncUploadState(syncUploadState as SyncUploadState.InProgress, it)
-        emit(syncUploadState)
-        // For terminal state we cancel the coroutine job that is collecting these states.
-        if (syncUploadState.isTerminalState()) awaitCancellation()
-      }
-    } else { // no requests to process
-      emit(SyncUploadState.Completed(0))
+    while (uploadRequestList.isNotEmpty()) {
+      // upload() is a cold flow with finite emitted values. Hence it ends automatically.
+      uploader
+        .upload(uploadRequestList)
+        .onEach { uploadResultProcessor.process(it) }
+        .scan(initialSyncUploadState, ::calculateSyncUploadState)
+        .drop(1)
+        .collect { emit(it) }
+      totalRequests += uploadRequestList.size
+      uploadRequestList = uploadRequestFetcher.fetchForUpload()
     }
+    emit(SyncUploadState.Completed(totalRequests))
   }
 
   private fun calculateSyncUploadState(
-    lastSyncUploadState: SyncUploadState.InProgress,
+    lastSyncUploadState: SyncUploadState,
     uploadResult: UploadResult
   ): SyncUploadState {
     /**
-     * The last states cannot be terminal states like Completed, Failed, NoOp. Hence the only
-     * possible last states are [SyncUploadState.Started] & [SyncUploadState.InProgress].
+     * The last state can be assumed as [SyncUploadState.InProgress] as that's the initial state we
+     * use to bootstrap the state calculation process.
      */
-    with(lastSyncUploadState) {
+    with(lastSyncUploadState as SyncUploadState.InProgress) {
       return when (uploadResult) {
         is UploadResult.Started -> {
           SyncUploadState.InProgress(
-            totalRequests = totalRequests,
+            currentTotalRequests = currentTotalRequests,
             completedRequests = completedRequests,
-            currentTotalBytes = uploadResult.uploadRequest.fileSize,
-            currentCompletedBytes = 0
+            currentRequestTotalBytes = uploadResult.uploadRequest.fileSize,
+            currentRequestCompletedBytes = 0
           )
         }
         is UploadResult.Success ->
           SyncUploadState.InProgress(
-            totalRequests = totalRequests,
+            currentTotalRequests = currentTotalRequests,
             completedRequests = completedRequests,
-            currentTotalBytes = currentTotalBytes,
-            currentCompletedBytes = currentCompletedBytes + uploadResult.bytesUploaded
+            currentRequestTotalBytes = currentRequestTotalBytes,
+            currentRequestCompletedBytes = currentRequestCompletedBytes + uploadResult.bytesUploaded
           )
         is UploadResult.Completed ->
-          if (completedRequests + 1 == totalRequests) SyncUploadState.Completed(totalRequests)
+          if (completedRequests + 1 == currentTotalRequests)
+            SyncUploadState.Completed(currentTotalRequests)
           else
             SyncUploadState.InProgress(
-              totalRequests = totalRequests,
+              currentTotalRequests = currentTotalRequests,
               completedRequests = completedRequests + 1,
-              currentTotalBytes = currentTotalBytes,
-              currentCompletedBytes = currentCompletedBytes
+              currentRequestTotalBytes = currentRequestTotalBytes,
+              currentRequestCompletedBytes = currentRequestCompletedBytes
             )
         is UploadResult.Failure -> SyncUploadState.Failed(exception = uploadResult.uploadError)
       }
     }
   }
 }
-
-internal fun SyncUploadState.isTerminalState() =
-  (this is SyncUploadState.Completed ||
-    this is SyncUploadState.Failed ||
-    this is SyncUploadState.NoOp)

--- a/sensing/src/main/java/com/google/android/sensing/upload/SyncUploadState.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/SyncUploadState.kt
@@ -45,7 +45,7 @@ open class SyncUploadState {
   data class Completed(val totalRequests: Int) : SyncUploadState()
 
   /** The sync failed for some [exception]. */
-  data class Failed(val exception: Exception) : SyncUploadState()
+  data class Failed(val resourceInfoId: String, val exception: Exception) : SyncUploadState()
 
   /**
    * This state indicates no operation. This is currently used to indicate that user's request to

--- a/sensing/src/main/java/com/google/android/sensing/upload/SyncUploadState.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/SyncUploadState.kt
@@ -23,22 +23,22 @@ open class SyncUploadState {
   val timestamp: OffsetDateTime = OffsetDateTime.now()
 
   /** The sync has started but nothing has progressed so far. */
-  data class Started(val totalRequests: Int) : SyncUploadState()
+  data class Started(val initialTotalRequests: Int) : SyncUploadState()
 
   /**
    * There is some progress represented by this state. It could be resource-level progress in case
-   * the resource is divided into parts to upload. This includes [currentTotalBytes] &
-   * [currentCompletedBytes]. This state can also be used to indicate a change in [totalRequests]
-   * being processed. This is possible when new [UploadRequest]s are created while current batch of
-   * requests are being processed.
+   * the resource is divided into parts to upload. This includes [currentRequestTotalBytes] &
+   * [currentRequestCompletedBytes]. This state can also be used to indicate a change in
+   * [currentTotalRequests] being processed. This is possible when new [UploadRequest]s are created
+   * while current batch of requests are being processed.
    *
    * TODO Add a state that helps to distinguish between different batches of upload.
    */
   data class InProgress(
-    val totalRequests: Int,
-    val completedRequests: Int,
-    val currentTotalBytes: Long,
-    val currentCompletedBytes: Long,
+    val currentTotalRequests: Int,
+    val completedRequests: Int = 0,
+    val currentRequestTotalBytes: Long = 0,
+    val currentRequestCompletedBytes: Long = 0,
   ) : SyncUploadState()
 
   /** The full sync has completed and there are are no further requests to be processed. */

--- a/sensing/src/main/java/com/google/android/sensing/upload/UploadRequestFetcher.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/UploadRequestFetcher.kt
@@ -25,7 +25,8 @@ interface UploadRequestFetcher {
   suspend fun fetchForUpload(): List<UploadRequest>
 }
 
-class DefaultUploadRequestFetcher(private val sensingEngine: SensingEngine) : UploadRequestFetcher {
+internal class DefaultUploadRequestFetcher(private val sensingEngine: SensingEngine) :
+  UploadRequestFetcher {
   override suspend fun fetchForUpload(): List<UploadRequest> {
     return (sensingEngine.listUploadRequest(status = RequestStatus.UPLOADING) +
       sensingEngine.listUploadRequest(status = RequestStatus.PENDING))


### PR DESCRIPTION
This pull request introduces enhancements to the synchronization logic for UploadRequest records, aiming to streamline the process and improve code clarity. The core logic of the synchronization is outlined in the `synchronize` function, which returns a Flow<SyncUploadState>.

The core logic is :-
```
suspend fun synchronize(): Flow<SyncUploadState> = flow {
  emit(SyncUploadState.Started)
  var uploadRequestList = uploadRequestFetcher.fetchForUpload()
  while (uploadRequestList.isNotEmpty()) {
    uploader
      .upload(uploadRequestList)
      .onEach { uploadResultProcessor.process(it) }
      .runningFold(initialSyncUploadState, ::calculateSyncUploadState)
      .drop(1)
      .collect { emit(it) }
    uploadRequestList = uploadRequestFetcher.fetchForUpload()
  }
  emit(SyncUploadState.Completed)
}
```

The process begins with emitting a SyncUploadState.Started signal. The uploadRequestFetcher is then employed to fetch a list of UploadRequest records for upload. The loop continues until no records are left to process.

Within the loop:
1. The uploader is utilized to upload the current batch of uploadRequestList.
2. The uploadResultProcessor processes each upload result.
3. The runningFold function is employed to calculate the SyncUploadState based on the previous "InProgress" states, with the initial state provided by initialSyncUploadState.
4. The first element of the folded result is dropped, and the subsequent SyncUploadState is emitted through the flow.

Additionally, variable names have been adjusted to better reflect the dynamic nature of totalRequests during upload in progress.

The overall result is a more streamlined and efficient synchronization process for managing UploadRequest records, enhancing code readability and addressing the mentioned issue.