### PR TITLE
Optimizing synchronization: release lock in finally block, synchronize block in the same coroutine

### DIFF
--- a/Sensory/src/main/java/com/google/android/sensory/HomeFragment.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/HomeFragment.kt
@@ -103,6 +103,7 @@ class HomeFragment : Fragment() {
   }
 
   private fun showSyncBanner(syncUploadState: SyncUploadState) {
+    if (syncUploadState is SyncUploadState.Started && syncUploadState.totalRequests == 0) return
     with(binding.uploadLayout) {
       if (linearLayoutUploadStatus.visibility != View.VISIBLE) {
         // may add fade in animation here later

--- a/sensing/src/main/java/com/google/android/sensing/SensingEngineProvider.kt
+++ b/sensing/src/main/java/com/google/android/sensing/SensingEngineProvider.kt
@@ -127,9 +127,9 @@ data class ServerConfiguration(
 /** A configuration to provide the network connection parameters. */
 data class NetworkConfiguration(
   /** Connection timeout (in seconds). The default is 10 seconds. */
-  val connectionTimeOut: Long = 10,
+  val connectionTimeOut: Long = 30,
   /** Write timeout (in seconds) for network connection. The default is 10 seconds. */
-  val writeTimeOut: Long = 10,
+  val writeTimeOut: Long = 30,
   /** Uploads should be multi part or not. */
   val isMultiPart: Boolean = true
 )

--- a/sensing/src/main/java/com/google/android/sensing/upload/Uploader.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/Uploader.kt
@@ -57,7 +57,6 @@ class Uploader(private val blobstoreService: BlobstoreService) {
             headers,
             null
           )
-        Timber.d("UploadID: ${uploadRequest.uploadId}")
         emit(
           UploadResult.Started(uploadRequest, Date.from(Instant.now()), uploadRequest.uploadId!!)
         )


### PR DESCRIPTION
Fixes #58 and #55 

Changes Made:
1. Removal of the separate coroutine launch for synchronization, leveraging the finite emit cold flow from synchronize().
2. Introducing a try-catch-finally block around synchronize() to handle exceptions.
3. Increasing the connection timeout to 30 seconds to address ConnectTimeoutException occurrences.

Positive side effect: elimination of the need for an additional coroutine for collecting SyncUploadStates.

Testing:
Network connection was deliberately shut off to observe the behavior during ConnectTimeoutException.
The lock is successfully released, and the worker returns Result.retry.
Successfully observe last set progress from both periodic and one time sync workers.