### PR TITLE
update ResourceInfo status properly

### DIFF
--- a/sensing/src/main/java/com/google/android/sensing/db/impl/dao/ResourceInfoDao.kt
+++ b/sensing/src/main/java/com/google/android/sensing/db/impl/dao/ResourceInfoDao.kt
@@ -105,7 +105,6 @@ internal fun ResourceInfoEntity.toResourceInfo() =
 
 internal fun ResourceInfo.toResourceInfoEntity() =
   ResourceInfoEntity(
-    id = 0,
     resourceInfoId = resourceInfoId,
     captureId = captureId,
     participantId = participantId,

--- a/sensing/src/main/java/com/google/android/sensing/db/impl/entities/ResourceInfoEntity.kt
+++ b/sensing/src/main/java/com/google/android/sensing/db/impl/entities/ResourceInfoEntity.kt
@@ -42,10 +42,8 @@ import com.google.android.sensing.model.RequestStatus
 )
 /** Information about the resource collected per capture. This is not involved in uploading. */
 internal data class ResourceInfoEntity(
-  @PrimaryKey(autoGenerate = true) val id: Long,
-
   /** Unique Id of this record. */
-  val resourceInfoId: String,
+  @PrimaryKey val resourceInfoId: String,
 
   /** Id of the capture that created this record. */
   val captureId: String,


### PR DESCRIPTION
Fixes #62 

We make `resourceInfoId` as PrimaryKey.

The @Update works only when primary key is present in the entity object.
Also id is removed as its not needed.

TESTED:-
<img width="1213" alt="Screenshot 2023-12-27 at 20 08 20" src="https://github.com/google-research/CVD-paper-mobile-camera-example/assets/22965002/ae468b53-898e-4926-b696-5234f703bbf1">
