### PR TITLE
Moving DB and SensingEngine singletons to their respective classes

### DIFF
--- a/Sensory/src/main/java/com/google/android/sensory/SensingApplication.kt
+++ b/Sensory/src/main/java/com/google/android/sensory/SensingApplication.kt
@@ -28,7 +28,6 @@ import com.google.android.sensing.DatabaseConfiguration
 import com.google.android.sensing.MinioInternalIDPAuthenticator
 import com.google.android.sensing.SensingEngine
 import com.google.android.sensing.SensingEngineConfiguration
-import com.google.android.sensing.SensingEngineProvider
 import com.google.android.sensing.ServerConfiguration
 import com.google.android.sensory.fhir_data.PPGSensorCaptureViewHolderFactory
 import com.google.android.sensory.fhir_data.PhotoCaptureViewHolderFactory
@@ -71,7 +70,7 @@ class SensingApplication :
   }
 
   private fun constructSensingEngine(): SensingEngine {
-    return SensingEngineProvider.getInstance(applicationContext)
+    return SensingEngine.getInstance(applicationContext)
   }
 
   companion object {

--- a/sensing/src/main/java/com/google/android/sensing/SensingEngineConfiguration.kt
+++ b/sensing/src/main/java/com/google/android/sensing/SensingEngineConfiguration.kt
@@ -16,31 +16,6 @@
 
 package com.google.android.sensing
 
-import android.annotation.SuppressLint
-import android.content.Context
-import com.google.android.sensing.db.impl.DatabaseImpl
-import com.google.android.sensing.impl.SensingEngineImpl
-
-object SensingEngineProvider {
-  @Volatile private var sensingEngine: SensingEngine? = null
-
-  @SuppressLint("UnsafeOptInUsageError")
-  fun getInstance(context: Context) =
-    sensingEngine
-      ?: synchronized(this) {
-        val appContext = context.applicationContext
-        val sensingEngineConfiguration =
-          if (appContext is SensingEngineConfiguration.Provider) {
-            appContext.getSensingEngineConfiguration()
-          } else SensingEngineConfiguration()
-        sensingEngine
-          ?: with(sensingEngineConfiguration) {
-            val database = DatabaseImpl(context, databaseConfiguration)
-            SensingEngineImpl(database, context, serverConfiguration).also { sensingEngine = it }
-          }
-      }
-}
-
 /**
  * A configuration which describes the database setup and error recovery.
  *

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureViewModel.kt
@@ -37,7 +37,7 @@ import com.google.android.fitbit.research.sensing.common.libraries.camera.camera
 import com.google.android.fitbit.research.sensing.common.libraries.camera.storage.WriteJpegFutureSubscriber
 import com.google.android.fitbit.research.sensing.common.libraries.flow.FlowGate
 import com.google.android.fitbit.research.sensing.common.libraries.storage.StreamToTsvSubscriber
-import com.google.android.sensing.SensingEngineProvider
+import com.google.android.sensing.SensingEngine
 import com.google.android.sensing.model.CaptureInfo
 import com.google.android.sensing.model.SensorType
 import com.google.common.util.concurrent.FutureCallback
@@ -239,9 +239,9 @@ class CaptureViewModel(application: Application) : AndroidViewModel(application)
    */
   fun invokeCaptureCompleteCallback() {
     CoroutineScope(context = Dispatchers.IO).launch {
-      SensingEngineProvider.getInstance(getApplication())
-        .onCaptureCompleteCallback(captureInfo)
-        .collect { captureResultLiveData.postValue(it) }
+      SensingEngine.getInstance(getApplication()).onCaptureCompleteCallback(captureInfo).collect {
+        captureResultLiveData.postValue(it)
+      }
     }
   }
 

--- a/sensing/src/main/java/com/google/android/sensing/db/Database.kt
+++ b/sensing/src/main/java/com/google/android/sensing/db/Database.kt
@@ -16,6 +16,9 @@
 
 package com.google.android.sensing.db
 
+import android.content.Context
+import com.google.android.sensing.DatabaseConfiguration
+import com.google.android.sensing.db.impl.DatabaseImpl
 import com.google.android.sensing.model.CaptureInfo
 import com.google.android.sensing.model.RequestStatus
 import com.google.android.sensing.model.ResourceInfo
@@ -34,4 +37,21 @@ internal interface Database {
   suspend fun getResourceInfo(resourceInfoId: String): ResourceInfo
   suspend fun getCaptureInfo(captureId: String): CaptureInfo
   suspend fun deleteRecordsInCapture(captureId: String): Boolean
+
+  companion object {
+    @Volatile private var instance: Database? = null
+    fun getInstance(context: Context, databaseConfig: DatabaseConfiguration) =
+      instance
+        ?: synchronized(this) {
+          instance
+            ?: DatabaseImpl(
+                context,
+                DatabaseConfiguration(
+                  databaseConfig.enableEncryption,
+                  databaseConfig.databaseErrorStrategy
+                )
+              )
+              .also { instance = it }
+        }
+  }
 }

--- a/sensing/src/main/java/com/google/android/sensing/impl/SensingEngineImpl.kt
+++ b/sensing/src/main/java/com/google/android/sensing/impl/SensingEngineImpl.kt
@@ -18,7 +18,6 @@ package com.google.android.sensing.impl
 
 import android.content.Context
 import android.content.Intent
-import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import com.google.android.sensing.SensingEngine
 import com.google.android.sensing.ServerConfiguration
 import com.google.android.sensing.capture.CaptureFragment
@@ -50,7 +49,6 @@ import kotlinx.coroutines.withContext
  * resources in the application context.
  * @param serverConfiguration
  */
-@ExperimentalCamera2Interop
 internal class SensingEngineImpl(
   private val database: Database,
   private val context: Context,

--- a/sensing/src/main/java/com/google/android/sensing/upload/UploadRequestFetcher.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/UploadRequestFetcher.kt
@@ -18,7 +18,6 @@ package com.google.android.sensing.upload
 
 import android.content.Context
 import com.google.android.sensing.SensingEngine
-import com.google.android.sensing.SensingEngineProvider
 import com.google.android.sensing.model.RequestStatus
 import com.google.android.sensing.model.UploadRequest
 
@@ -34,7 +33,7 @@ interface UploadRequestFetcher {
       instance
         ?: synchronized(this) {
           instance
-            ?: DefaultUploadRequestFetcher(SensingEngineProvider.getInstance(context)).also {
+            ?: DefaultUploadRequestFetcher(SensingEngine.getInstance(context)).also {
               instance = it
             }
         }

--- a/sensing/src/main/java/com/google/android/sensing/upload/UploadResultProcessor.kt
+++ b/sensing/src/main/java/com/google/android/sensing/upload/UploadResultProcessor.kt
@@ -18,7 +18,6 @@ package com.google.android.sensing.upload
 
 import android.content.Context
 import com.google.android.sensing.SensingEngine
-import com.google.android.sensing.SensingEngineProvider
 import com.google.android.sensing.model.RequestStatus
 import com.google.android.sensing.model.UploadResult
 import java.io.File
@@ -39,7 +38,7 @@ interface UploadResultProcessor {
       instance
         ?: synchronized(this) {
           instance
-            ?: DefaultUploadResultProcessor(SensingEngineProvider.getInstance(context)).also {
+            ?: DefaultUploadResultProcessor(SensingEngine.getInstance(context)).also {
               instance = it
             }
         }


### PR DESCRIPTION
Extending PR #61 
Moving the db singleton instance is required to use from other interfaces apart from SensingEngine interface.

Application to now directly use `SensingEngine.getInstance(context)` instead of `SensingEngineProvider.getOrCreate(context)`