### PR TITLE
Restore uploading data + metadata

### DIFF
--- a/sensing/src/main/java/com/google/android/sensing/SensorManager.kt
+++ b/sensing/src/main/java/com/google/android/sensing/SensorManager.kt
@@ -200,9 +200,12 @@ interface SensorManager {
                   } else SensingEngineConfiguration()
                 with(sensingEngineConfiguration) {
                   val database = Database.getInstance(context, databaseConfiguration)
-                  SensorManagerImpl(context, database).apply {
-                    registerSensorFactory(InternalSensorType.CAMERA, CameraSensorFactor)
-                  }
+                  SensorManagerImpl(
+                      context,
+                      database,
+                      sensingEngineConfiguration.serverConfiguration
+                    )
+                    .apply { registerSensorFactory(InternalSensorType.CAMERA, CameraSensorFactor) }
                 }
               }
               .also { instance = it }

--- a/sensing/src/main/java/com/google/android/sensing/capture/CaptureUtil.kt
+++ b/sensing/src/main/java/com/google/android/sensing/capture/CaptureUtil.kt
@@ -16,43 +16,25 @@
 
 package com.google.android.sensing.capture
 
-import android.content.Context
-import android.content.res.ColorStateList
-import androidx.camera.core.TorchState
-import androidx.core.content.ContextCompat
-import com.google.android.fitbit.research.sensing.common.libraries.camera.Camera2InteropSensor
-import com.google.android.material.floatingactionbutton.FloatingActionButton
-import com.google.android.sensing.R
-import com.google.android.sensing.model.CaptureType
-import com.google.android.sensing.model.InternalSensorType
+import java.io.BufferedOutputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 class CaptureUtil {
   companion object {
-    fun toggleFlashWithView(
-      camera: Camera2InteropSensor,
-      toggleFlashFab: FloatingActionButton,
-      context: Context
-    ) {
-      val c = camera.cameraXSensor.camera
-      if (c!!.cameraInfo.torchState.value == TorchState.ON) {
-        // Turn off flash
-        c.cameraControl.enableTorch(false)
-        toggleFlashFab.setImageResource(R.drawable.flashlight_off)
-        toggleFlashFab.backgroundTintList =
-          ColorStateList.valueOf(ContextCompat.getColor(context, android.R.color.black))
-      } else {
-        // Turn on flash
-        c.cameraControl.enableTorch(true)
-        toggleFlashFab.setImageResource(R.drawable.flashlight_on)
-        toggleFlashFab.backgroundTintList =
-          ColorStateList.valueOf(ContextCompat.getColor(context, R.color.colorPrimary))
-      }
-    }
-
-    fun sensorsInvolved(captureType: CaptureType): List<InternalSensorType> {
-      return when (captureType) {
-        CaptureType.VIDEO_PPG -> listOf(InternalSensorType.CAMERA)
-        CaptureType.IMAGE -> listOf(InternalSensorType.CAMERA)
+    fun zipDirectory(sourceDirPath: Path, zipPath: Path) {
+      ZipOutputStream(BufferedOutputStream(FileOutputStream(zipPath.toFile()))).use { zipOut ->
+        Files.walk(sourceDirPath)
+          .filter { path -> !Files.isDirectory(path) } // Exclude directories from the initial walk
+          .forEach { path ->
+            val zipEntry = ZipEntry(sourceDirPath.relativize(path).toString())
+            zipOut.putNextEntry(zipEntry)
+            Files.copy(path, zipOut)
+            zipOut.closeEntry()
+          }
       }
     }
   }


### PR DESCRIPTION
Fixes #95 

More information in the issue.
This is simply restoring the UploadRequest record creation we used to do earlier in `SensingEngineImpl`. 

The current design is to be improved by introducing a default PostProcessor which would be responsible for all database consolidation (creation of CaptureInfo, ResourceInfo & UploadRequest records) - similar to [DefaultConsolidator in FhirEngine](https://github.com/google/android-fhir/blob/4742e60025df236abaca3884747f8429d68b504f/engine/src/main/java/com/google/android/fhir/sync/upload/ResourceConsolidator.kt#L42).