### PR TITLE
Fixes for UNIQUE constraint failure exception 

### DIFF
--- a/sensing/src/main/java/com/google/android/sensing/SensingEngine.kt
+++ b/sensing/src/main/java/com/google/android/sensing/SensingEngine.kt
@@ -36,8 +36,11 @@ interface SensingEngine {
   /** Get CaptureInfo record given @param captureId */
   suspend fun getCaptureInfo(captureId: String): CaptureInfo
 
+  /** Get CaptureInfo record given @param captureFolder */
+  suspend fun getCaptureInfoByFolder(captureFolder: String): CaptureInfo?
+
   /** Delete all data associated with [captureId] */
-  suspend fun deleteDataInCapture(captureId: String): Boolean
+  suspend fun deleteDataInCapture(captureId: String, isRecapture: Boolean): Boolean
 
   /**
    * Responsible for creating resource records for captured data and completing upload setup. This

--- a/sensing/src/main/java/com/google/android/sensing/db/Database.kt
+++ b/sensing/src/main/java/com/google/android/sensing/db/Database.kt
@@ -38,5 +38,6 @@ internal interface Database {
   suspend fun updateResourceInfo(resourceInfo: ResourceInfo)
   suspend fun getResourceInfo(resourceInfoId: String): ResourceInfo
   suspend fun getCaptureInfo(captureId: String): CaptureInfo
+  suspend fun getCaptureInfoByFolder(captureFolder: String): CaptureInfo?
   suspend fun deleteRecordsInCapture(captureId: String): Boolean
 }

--- a/sensing/src/main/java/com/google/android/sensing/db/impl/DatabaseImpl.kt
+++ b/sensing/src/main/java/com/google/android/sensing/db/impl/DatabaseImpl.kt
@@ -100,6 +100,10 @@ internal class DatabaseImpl(context: Context, databaseConfig: DatabaseConfigurat
       ?: throw ResourceNotFoundException("CaptureInfo", captureId)
   }
 
+  override suspend fun getCaptureInfoByFolder(captureFolder: String): CaptureInfo? {
+    return captureInfoDao.getCaptureInfoByFolder(captureFolder)
+  }
+
   override suspend fun deleteRecordsInCapture(captureId: String): Boolean {
     /* We only need to delete CaptureInfo record as we CASCADE it. */
     return captureInfoDao.deleteCaptureInfo(captureId) == 1

--- a/sensing/src/main/java/com/google/android/sensing/db/impl/dao/CaptureInfoDao.kt
+++ b/sensing/src/main/java/com/google/android/sensing/db/impl/dao/CaptureInfoDao.kt
@@ -48,6 +48,16 @@ internal abstract class CaptureInfoDao {
   }
 
   @Query("""
+    SELECT * FROM CaptureInfoEntity WHERE captureFolder=:captureFolder
+  """)
+  abstract suspend fun getCaptureInfoEntityByFolder(captureFolder: String): CaptureInfoEntity?
+
+  @Transaction
+  open suspend fun getCaptureInfoByFolder(captureFolder: String): CaptureInfo? {
+    return getCaptureInfoEntityByFolder(captureFolder)?.toCaptureInfo()
+  }
+
+  @Query("""
     DELETE FROM CaptureInfoEntity WHERE captureId=:captureId
   """)
   abstract suspend fun deleteCaptureInfo(captureId: String): Int

--- a/sensing/src/main/java/com/google/android/sensing/impl/SensingEngineImpl.kt
+++ b/sensing/src/main/java/com/google/android/sensing/impl/SensingEngineImpl.kt
@@ -60,14 +60,18 @@ internal class SensingEngineImpl(
 
   /** TODO Move zipping and creation of UploadRequest to sync section. */
   override suspend fun onCaptureCompleteCallback(captureInfo: CaptureInfo) = flow {
-    if (captureInfo.recapture == true) {
-      try {
-        val inRecordCaptureInfo = getCaptureInfo(captureInfo.captureId!!)
-        deleteDataInCapture(inRecordCaptureInfo.captureId!!)
-        moveDataFromCacheToFiles(inRecordCaptureInfo.captureFolder)
-      } catch (_: ResourceNotFoundException) {}
-    } // else we don't need to worry about it because the capture module stored data in the
-    // internal filesDir
+    try {
+      val inRecordCaptureInfo =
+        if (captureInfo.recapture == true) {
+          getCaptureInfo(captureInfo.captureId!!)
+        } else {
+          getCaptureInfoByFolder(captureInfo.captureFolder)
+        }
+      inRecordCaptureInfo?.let { info ->
+        deleteDataInCapture(info.captureId!!, captureInfo.recapture == true)
+        moveDataFromCacheToFiles(info.captureFolder)
+      }
+    } catch (_: ResourceNotFoundException) {}
     database.addCaptureInfo(captureInfo)
     emit(SensorCaptureResult.CaptureInfoCreated(captureInfo))
     CaptureUtil.sensorsInvolved(captureInfo.captureType).forEach {
@@ -169,7 +173,11 @@ internal class SensingEngineImpl(
     return database.getCaptureInfo(captureId)
   }
 
-  override suspend fun deleteDataInCapture(captureId: String): Boolean {
+  override suspend fun getCaptureInfoByFolder(captureFolder: String): CaptureInfo? {
+    return database.getCaptureInfoByFolder(captureFolder)
+  }
+
+  override suspend fun deleteDataInCapture(captureId: String, isRecapture: Boolean): Boolean {
     val captureInfo =
       try {
         getCaptureInfo(captureId)
@@ -179,18 +187,21 @@ internal class SensingEngineImpl(
 
     // Step 1: Delete db records
     database.deleteRecordsInCapture(captureId)
-    // Step 2: delete the captureFolder
-    val captureFile = File(context.filesDir, captureInfo.captureFolder)
-    val parentFile = captureFile.parentFile
-    val deleted: Boolean
-    withContext(Dispatchers.IO) {
-      deleted = captureFile.deleteRecursively()
-      // delete Participant's folder if there are no data
-      if (parentFile?.list()?.isEmpty() == true) {
-        parentFile.delete()
+    if (isRecapture) {
+      // Step 2: delete the captureFolder
+      val captureFile = File(context.filesDir, captureInfo.captureFolder)
+      val parentFile = captureFile.parentFile
+      val deleted: Boolean
+      withContext(Dispatchers.IO) {
+        deleted = captureFile.deleteRecursively()
+        // delete Participant's folder if there are no data
+        if (parentFile?.list()?.isEmpty() == true) {
+          parentFile.delete()
+        }
       }
+      return deleted
     }
-    return deleted
+    return false
   }
 
   override suspend fun deleteSensorData(uploadURL: String) {


### PR DESCRIPTION
Handled recapture case when we reopen media capture form for an existing patient without submitting the previous form - fixes for UNIQUE constraint failure exception in such case


For Example : 

android.database.sqlite.SQLiteConstraintException: UNIQUE constraint failed: CaptureInfoEntity.captureFolder (code 2067 SQLITE_CONSTRAINT_UNIQUE[2067]) at android.database.sqlite.SQLiteConnection.nativeExecuteForLastInsertedRowId(Native Method) at android.database.sqlite.SQLiteConnection.executeForLastInsertedRowId(SQLiteConnection.java:1293) at android.database.sqlite.SQLiteSession.executeForLastInsertedRowId(SQLiteSession.java:790) at android.database.sqlite.SQLiteStatement.executeInsert(SQLiteStatement.java:89) at androidx.sqlite.db.framework.FrameworkSQLiteStatement.executeInsert(FrameworkSQLiteStatement.kt:42) at androidx.room.EntityInsertionAdapter.insert(EntityInsertionAdapter.kt:52) at com.google.android.sensing.db.impl.dao.CaptureInfoDao_Impl$3.call(CaptureInfoDao_Impl.java:106) at com.google.android.sensing.db.impl.dao.CaptureInfoDao_Impl$3.call(CaptureInfoDao_Impl.java:101) at androidx.room.CoroutinesRoom$Companion.execute(CoroutinesRoom.kt:57) at androidx.room.CoroutinesRoom.execute(Unknown Source:2) at com.google.android.sensing.db.impl.dao.CaptureInfoDao_Impl.insertCaptureInfoEntity(CaptureInfoDao_Impl.java:101) at com.google.android.sensing.db.impl.dao.CaptureInfoDao.insertCaptureInfo$suspendImpl(CaptureInfoDao.kt:36) at com.google.android.sensing.db.impl.dao.CaptureInfoDao.insertCaptureInfo(Unknown Source:0) at com.google.android.sensing.db.impl.dao.CaptureInfoDao_Impl.access$601(CaptureInfoDao_Impl.java:36) at com.google.android.sensing.db.impl.dao.CaptureInfoDao_Impl.lambda$insertCaptureInfo$0$com-google-android-sensing-db-impl-dao-CaptureInfoDao_Impl(CaptureInfoDao_Impl.java:119) at com.google.android.sensing.db.impl.dao.CaptureInfoDao_Impl$$ExternalSyntheticLambda0.invoke(Unknown Source:6) at androidx.room.RoomDatabaseKt$withTransaction$transactionBlock$1.invokeSuspend(RoomDatabaseExt.kt:56) at androidx.room.RoomDatabaseKt$withTransaction$transactionBlock$1.invoke(Unknown Source:8) at androidx.room.RoomDatabaseKt$withTransaction$transactionBlock$1.invoke(Unknown Source:4) at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:89) at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:169) at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1) at androidx.room.RoomDatabaseKt$startTransactionCoroutine$2$1$1.invokeSuspend(RoomDatabaseExt.kt:97) at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106) at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:284) at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85) at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59) at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source:1) at androidx.room.RoomDatabaseKt$startTransactionCoroutine$2$1.run(RoomDatabaseExt.kt:93) at androidx.room.TransactionExecutor.execute$lambda$1$lambda$0(TransactionExecutor.kt:36) at androidx.room.TransactionExecutor.$r8$lambda$AympDHYBb78s7_N_9gRsXF0sHiw(Unknown Source:0) at androidx.room.TransactionExecutor$$ExternalSyntheticLambda0.run(Unknown Source:4) at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644) at java.lang.Thread.run(Thread.java:1012) Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@29afe57, Dispatchers.IO]	